### PR TITLE
Update zhalightlevel.go

### DIFF
--- a/deconz/sensor/zhalightlevel.go
+++ b/deconz/sensor/zhalightlevel.go
@@ -6,7 +6,7 @@ type ZHALightLevel struct {
 	Dark       bool
 	Daylight   bool
 	LightLevel int32
-	Lux        int16
+	Lux        int32
 }
 
 // Fields implements the fielder interface and returns time series data for InfluxDB


### PR DESCRIPTION
fix for

time="2022-03-10T09:31:02+01:00" level=warning msg="unable to decode state: json: cannot unmarshal number 41476 into Go struct field ZHALightLevel.Lux of type int16"
time="2022-03-10T09:31:11+01:00" level=error msg="Dropping event due to error: unable to parse message: unable to decode state: json: cannot unmarshal number 41620 into Go struct field ZHALightLevel.Lux of type int16"